### PR TITLE
Update sensor.py

### DIFF
--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -54,7 +54,7 @@ SENSOR_TYPES = {
 ENDPOINTS = {
     "diskspace": "{0}://{1}:{2}/{3}api/diskspace",
     "queue": "{0}://{1}:{2}/{3}api/queue",
-    "upcoming": "{0}://{1}:{2}/{3}api/calendar?start={4}&end={5}",
+    "upcoming": "{0}://{1}:{2}/{3}api/calendar?start={4}T00:00:00Z&end={5}T23:59:59Z",
     "wanted": "{0}://{1}:{2}/{3}api/wanted/missing",
     "series": "{0}://{1}:{2}/{3}api/series",
     "commands": "{0}://{1}:{2}/{3}api/command",
@@ -206,7 +206,7 @@ class SonarrSensor(Entity):
     def update(self):
         """Update the data for the sensor."""
         start = get_date(self._tz)
-        end = get_date(self._tz, self.days)
+        end = get_date(self._tz, self.days - 1)
         try:
             res = requests.get(
                 ENDPOINTS[self.type].format(
@@ -227,7 +227,7 @@ class SonarrSensor(Entity):
                     # Sonarr API returns an empty array if start and end dates
                     # are the same, so we need to filter to just today
                     self.data = list(
-                        filter(lambda x: x["airDate"] == str(start), res.json())
+                        filter(lambda x: str(start) in x["airDateUtc"], res.json())
                     )
                 else:
                     self.data = res.json()


### PR DESCRIPTION
fixed start and end times and filter for 1 day only UTC times



## Proposed change

  This add-on when set to return only today (days:1) it would return zero items, when (days:2) it would return 3 days of items.

  The sonarr api would return items as such
```
    "airDate": "2020-04-12",
    "airDateUtc": "2020-04-13T02:00:00Z",
```
  Where the airDate is the date it airs in the country of airing, but the airDateUTC was the date it aired for me in local time. The current code gets my date now (2020-04-13) and tested if it matched the field airDate (2020-04-12) and nothing would return.

  This PR addresses the problems with this and locally in my system this is now working correctly no matter how many days are selected with this code change.


## Type of change
- [ ] Dependency upgrade
- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- This PR is related to issue: 13277


## Checklist
- [x ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.



- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

